### PR TITLE
no_push_on_next_release

### DIFF
--- a/releaser/next_release.py
+++ b/releaser/next_release.py
@@ -67,4 +67,6 @@ def add_release(local_repository, package_name, module_name, release_name, branc
     update_changelog(config)
     config['release_name'] += '-dev'
     update_version(config)
-    push(config)
+    # we should NOT push by default as next_release can be called when the working copy is on a branch (when we want to
+    # add release notes for features which are not targeted for the current release)
+    # push(config)

--- a/releaser/utils.py
+++ b/releaser/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # coding=utf-8
 from __future__ import print_function, unicode_literals
 
@@ -9,9 +8,8 @@ import os
 import re
 import stat
 import zipfile
-import subprocess
 from os.path import join
-from shutil import copytree, copy2, rmtree as _rmtree
+from shutil import rmtree as _rmtree
 from subprocess import check_output, STDOUT, CalledProcessError
 
 


### PR DESCRIPTION
avoid pushing automatically after adding the release. It can lead to unexpected/undesired results when you just want to add release notes to a WIP feature branch
(by default it pushes the master branch upstream when you did not want to push anything and are working on an unrelated branch).

There is surely a better fix (namely to only push when it makes sense) but I don't have a clear enough mind right now to determine the
condition for that and it is better to do nothing than do something surprising and potentially harmful.